### PR TITLE
Update whitelist.yaml

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -30,3 +30,5 @@
   - url: "*.tistory.com"
   - url: "*.surge.sh"
   - url: revoke.cash
+  - url: "*.binance.events"
+  - url: www.binance.events


### PR DESCRIPTION
whitelist for the legit domain of www.binance.events

